### PR TITLE
Be optimistic with jcocoa library, in case it is already loaded.

### DIFF
--- a/java/src/ca/weblite/objc/RuntimeUtils.java
+++ b/java/src/ca/weblite/objc/RuntimeUtils.java
@@ -56,12 +56,17 @@ public class RuntimeUtils {
     public static boolean loaded = false;
     static {
         try {
-            System.loadLibrary("jcocoa");
+            init();     // Be optimistic; probably it is already loaded
             loaded = true;
-        } catch (UnsatisfiedLinkError err){
-            err.printStackTrace(System.err);
+        } catch (UnsatisfiedLinkError err1) {
+            try {
+                System.loadLibrary("jcocoa");
+                init();
+                loaded = true;
+            } catch (UnsatisfiedLinkError err2) {
+                err2.printStackTrace(System.err);
+            }
         }
-        init();
     }
     
     


### PR DESCRIPTION
Just be a little more optimisitc with native library loading, in case it is already loaded in advance with something like
 System.load(".../libjcocoa.dylib");
in order to get rid of the java.library.path depedency, in case we already know the absolute library path.
