### PR TITLE
Remove System.out.println() call in Proxy.toString()

### DIFF
--- a/src/main/java/ca/weblite/objc/Proxy.java
+++ b/src/main/java/ca/weblite/objc/Proxy.java
@@ -501,7 +501,6 @@ public class Proxy implements Peerable {
      */
     @Override
     public String toString(){
-        System.out.println("The peer is "+getPeer());
         if ( getPeer() == null ){
             return "null";
         }


### PR DESCRIPTION
`Proxy.toString()` contains an unconditional call to `System.out.println()` which is undesirable for any clients of the library which output to stdout.

In particular, this breaks the [Buck](https://github.com/facebook/buck) project because it outputs JSON to stdout and the calls to `Proxy.toString()` end up breaking the structured output.